### PR TITLE
Use self-export over ./ export

### DIFF
--- a/callBound.js
+++ b/callBound.js
@@ -2,7 +2,7 @@
 
 var GetIntrinsic = require('get-intrinsic');
 
-var callBind = require('./');
+var callBind = require('call-bind');
 
 var $indexOf = callBind(GetIntrinsic('String.prototype.indexOf'));
 


### PR DESCRIPTION
This updates the self-import to use the direct self-export form over using `./` as a placeholder for a self-import.

That `require('./')` inside of CJS packages with exports still works is a legacy path that we should try and deprecate I think, especially since these specifiers cannot be mapped with import maps.